### PR TITLE
#5 🍭 example: provide example env for project root

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+PROJECT_ROOT='/workspace/terraform-beginner-bootcamp-2023'

--- a/README.md
+++ b/README.md
@@ -100,3 +100,54 @@ https://en.wikipedia.org/wiki/Chmod
 We need to be careful when using the Init because it will not rerun if we restart an existing workspace.
 
 https://www.gitpod.io/docs/configure/workspaces/tasks
+
+### Working Env Vars
+
+#### env command
+
+We can list out all Enviroment Variables (Env Vars) using the `env` command
+
+We can filter specific env vars using grep eg. `env | grep AWS_`
+
+#### Setting and Unsetting Env Vars
+
+In the terminal we can set using `export HELLO='world`
+
+In the terrminal we unset using `unset HELLO`
+
+We can set an env var temporarily when just running a command
+
+```sh
+HELLO='world' ./bin/print_message
+```
+Within a bash script we can set env without writing export eg.
+
+```sh
+#!/usr/bin/env bash
+
+HELLO='world'
+
+echo $HELLO
+```
+
+#### Printing Vars
+
+We can print an env var using echo eg. `echo $HELLO`
+
+#### Scoping of Env Vars
+
+When you open up new bash terminals in VSCode it will not be aware of env vars that you have set in another window.
+
+If you want to Env Vars to persist across all future bash terminals that are open you need to set env vars in your bash profile. eg. `.bash_profile`
+
+#### Persisting Env Vars in Gitpod
+
+We can persist env vars into gitpod by storing them in Gitpod Secrets Storage.
+
+```
+gp env HELLO='world'
+```
+
+All future workspaces launched will set the env vars for all bash terminals opened in thoes workspaces.
+
+You can also set en vars in the `.gitpod.yml` but this can only contain non-senstive env vars.

--- a/bin/install_terraform_cli
+++ b/bin/install_terraform_cli
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+cd /workspace
+
 sudo apt-get update && sudo apt-get install -y gnupg software-properties-common curl
 
 wget -O- https://apt.releases.hashicorp.com/gpg | \
@@ -17,3 +19,5 @@ sudo tee /etc/apt/sources.list.d/hashicorp.list
 sudo apt update
 
 sudo apt-get install terraform -y
+
+cd $PROJECT_ROOT


### PR DESCRIPTION
- [x] Set environment variable for PROJECT_ROOT that we can reference in our bash scripts